### PR TITLE
Update syntax in error message about unboxing.

### DIFF
--- a/lib/imp/lang/pass/parse.zig
+++ b/lib/imp/lang/pass/parse.zig
@@ -688,7 +688,7 @@ pub const Parser = struct {
                             const name = (try self.expect(.Name)).Name;
                             break :arg syntax.Arg{ .name = name, .unbox = true };
                         },
-                        else => return self.setError(start, "Expected ?name or ?[name], found ?{}", .{arg_token}),
+                        else => return self.setError(start, "Expected ?name or ?@name, found ?{}", .{arg_token}),
                     }
                 };
                 const body = try self.parseExpr();


### PR DESCRIPTION
This error message had the old syntax for unboxing.